### PR TITLE
Fixed gcca.fit_transform()

### DIFF
--- a/gcca/gcca.py
+++ b/gcca/gcca.py
@@ -151,8 +151,8 @@ class GCCA:
         return z_list
 
     def fit_transform(self, *x_list):
-        self.fit(x_list)
-        self.transform(x_list)
+        self.fit(*x_list)
+        return self.transform(*x_list)
 
     @staticmethod
     def normalize(mat):


### PR DESCRIPTION
Fix the _gcca.fit_transform_ function to call the _fit_ function with its args to an iterable, the same as the call of the _transform_ function.
Included also a return for the call of the _transform_ function.